### PR TITLE
Concurrent write transactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - run: apt-get install llvm-dev
       - run: cargo install cargo-fuzz
       - run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 -timeout=5 || exit 1; done
       - run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,16 +114,16 @@ jobs:
           override: true
       - run: cargo install cargo-fuzz
       - run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 -timeout=5 || exit 1; done
-      - run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
-      - run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
+      - run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2
+      - run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2
       - env:
           NUM_ACTORS: 2
           MAX_WRITERS: 2
-        run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
+        run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2
       - env:
           NUM_ACTORS: 2
           MAX_WRITERS: 2
-        run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
+        run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2
 
   lint:
     name: Rustfmt & Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - run: apt-get install llvm-dev
+      - run: sudo apt-get install -y llvm-dev
       - run: cargo install cargo-fuzz
       - run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 -timeout=5 || exit 1; done
       - run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=600 -timeout=5 -jobs=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
       - run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 -timeout=5 || exit 1; done
       - run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
       - run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
+      - env:
+          NUM_ACTORS: 2
+          MAX_WRITERS: 2
+        run: cargo fuzz run fuzz_database -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
+      - env:
+          NUM_ACTORS: 2
+          MAX_WRITERS: 2
+        run: cargo fuzz run fuzz_database --features=failpoints -- -detect_leaks=0 -len_control=0 -max_total_time=300 -timeout=5 -jobs=2
 
   lint:
     name: Rustfmt & Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std"] }
 memmap2 = "0.9"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 rand = { version = "0.8" }
-xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
+# pinned until https://github.com/DoumanAsh/xxhash-rust/issues/50 is resolved
+xxhash-rust = { version = "=0.8.12", features = ["xxh3"] }
 zerocopy = { version = "0.7", default-features = false, features = ["derive"] }
 shuttle = { version = "0.7", optional = true }
 hashbrown = "0.14.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std"] }
 memmap2 = "0.9"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 rand = { version = "0.8" }
-# pinned until https://github.com/DoumanAsh/xxhash-rust/issues/50 is resolved
-xxhash-rust = { version = "=0.8.12", features = ["xxh3"] }
+xxhash-rust = { version = "0.8.14", features = ["xxh3"] }
 zerocopy = { version = "0.7", default-features = false, features = ["derive"] }
 shuttle = { version = "0.8", optional = true }
 hashbrown = "0.14.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std"] }
 memmap2 = "0.9"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 rand = { version = "0.8" }
-xxhash-rust = { version = "0.8.14", features = ["xxh3"] }
+# pinned until https://github.com/DoumanAsh/xxhash-rust/issues/50 is resolved
+xxhash-rust = { version = "=0.8.12", features = ["xxh3"] }
 zerocopy = { version = "0.7", default-features = false, features = ["derive"] }
 shuttle = { version = "0.8", optional = true }
 hashbrown = "0.14.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = { version = "0.8" }
 # pinned until https://github.com/DoumanAsh/xxhash-rust/issues/50 is resolved
 xxhash-rust = { version = "=0.8.12", features = ["xxh3"] }
 zerocopy = { version = "0.7", default-features = false, features = ["derive"] }
-shuttle = { version = "0.7", optional = true }
+shuttle = { version = "0.8", optional = true }
 hashbrown = "0.14.5"
 sptr = "0.3.2"
 serde_json = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Embedded Key-Value Storage Engine
 * Efficient async durability with background WAL fsyncs (e.g. every 500ms)
 * Bounded recovery times using an optional Write-Ahead-Log (WAL)
 * Concurrent write transactions with optimistic concurrency control
-* ACID transactions with serializable snapshot isolation (SSI) or snapshot isolation (SSI)
+* ACID transactions with serializable snapshot isolation (SSI) or snapshot isolation (SI)
 * Multi-Version-Concurrency-Control (MVCC) - writers do not block readers and vice versa
 * Long running read transactions have limited impact on the database
 * Supports larger than memory transactions

--- a/examples/one_env_many_dbs.rs
+++ b/examples/one_env_many_dbs.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut options = EnvOptions::new(_dir.path());
     // all databases in the same environment will share this 1GB cache
     options.page_cache_size = 1024 * 1024 * 1024;
-    let env = Environment::new(_dir.path()).unwrap();
+    let env = Environment::with_options(options).unwrap();
 
     let db1 = env.get_or_create_database("db1").unwrap();
     let db2 = env.get_or_create_database("db2").unwrap();

--- a/fuzz/fuzz_targets/fuzz_database.rs
+++ b/fuzz/fuzz_targets/fuzz_database.rs
@@ -538,16 +538,16 @@ impl Actor {
                     "key {:?}",
                     EscapedBytes(k.as_ref())
                 );
-                // let mut range = tree.range(k..=k).unwrap();
-                // let (k1, v1) = range.next().unwrap().unwrap();
-                // assert_eq!(EscapedBytes(k), EscapedBytes(k1.as_ref()));
-                // assert_eq!(
-                //     EscapedBytes(mv),
-                //     EscapedBytes(v1.as_ref()),
-                //     "key {:?}",
-                //     EscapedBytes(k.as_ref())
-                // );
-                // assert!(range.next().is_none());
+                let mut range = tree.range(k..=k).unwrap();
+                let (k1, v1) = range.next().unwrap().unwrap();
+                assert_eq!(EscapedBytes(k), EscapedBytes(k1.as_ref()));
+                assert_eq!(
+                    EscapedBytes(mv),
+                    EscapedBytes(v1.as_ref()),
+                    "key {:?}",
+                    EscapedBytes(k.as_ref())
+                );
+                assert!(range.next().is_none());
             }
             assert_eq!(tree.len() as usize, model.len());
         }
@@ -584,7 +584,7 @@ fuzz_target!(|ops: Vec<Op>| {
     db_options.checkpoint_interval = std::time::Duration::MAX;
     db_options.use_wal = test_recovery;
     db_options.default_commit_sync = false;
-    // db_options.checkpoint_target_size = 16 * 4096 as usize;
+    db_options.checkpoint_target_size = 16 * 4096 as usize;
     let db = canopydb::Database::with_options(options.clone(), db_options.clone()).unwrap();
     let mut world = World {
         state: WorldState {

--- a/fuzz/fuzz_targets/fuzz_database.rs
+++ b/fuzz/fuzz_targets/fuzz_database.rs
@@ -219,7 +219,7 @@ type ModelTreeMut = BTreeMap<Bytes, Bytes>;
 type ModelTree = Rc<ModelTreeMut>;
 type ModelTreeRef<'a> = &'a ModelTreeMut;
 const NUM_ACTORS: usize = 2;
-const MAX_WRITERS: usize = 2;
+const MAX_WRITERS: usize = 1;
 
 struct WorldState {
     writers: BTreeSet<ActorId>,

--- a/fuzz/fuzz_targets/fuzz_database.rs
+++ b/fuzz/fuzz_targets/fuzz_database.rs
@@ -4,7 +4,7 @@ use canopydb::{utils::EscapedBytes, Error};
 use libfuzzer_sys::fuzz_target;
 use rand::{distributions::Alphanumeric, Rng, SeedableRng};
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     mem,
     ops::Bound,
     rc::Rc,
@@ -101,7 +101,7 @@ struct BytesN<const MIN: usize, const MAX: usize>(Rc<Vec<u8>>);
 
 impl<'a, const MIN: usize, const MAX: usize> std::fmt::Debug for BytesN<MIN, MAX> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &EscapedBytes(&self.0))
+        write!(f, "`{:?}`", &EscapedBytes(&self.0))
     }
 }
 
@@ -219,9 +219,10 @@ type ModelTreeMut = BTreeMap<Bytes, Bytes>;
 type ModelTree = Rc<ModelTreeMut>;
 type ModelTreeRef<'a> = &'a ModelTreeMut;
 const NUM_ACTORS: usize = 2;
+const MAX_WRITERS: usize = 2;
 
 struct WorldState {
-    writter: Option<ActorId>,
+    writers: BTreeSet<ActorId>,
     db: canopydb::Database,
     model: ModelTree,
     read_queue: VecDeque<ActorId>,
@@ -237,7 +238,7 @@ struct World {
 enum Tx {
     None,
     Read(ModelTree, canopydb::ReadTransaction),
-    Write(ModelTreeMut, canopydb::WriteTransaction),
+    Write(ModelTreeMut, canopydb::WriteTransaction, ModelTree),
 }
 
 impl Default for Tx {
@@ -255,10 +256,7 @@ struct Actor {
 }
 
 impl Actor {
-    fn op(&mut self, state: &mut WorldState, new_op: Option<Op>) {
-        if let Some(op) = new_op {
-            self.op_queue.push_back(op);
-        }
+    fn op(&mut self, state: &mut WorldState) {
         while let Some(op) = self.op_queue.pop_front() {
             if match op {
                 Op::Commit(_, failure) => self.commit(state, failure),
@@ -281,21 +279,34 @@ impl Actor {
                 Self::validate(state, &model, &rx);
                 false
             }
-            Tx::Write(model, tx) => {
+            Tx::Write(model, tx, starting) => {
                 let tx_id = tx.tx_id();
                 trace!("commiting {}", tx_id);
                 Self::validate(state, &model, &tx);
                 match failure.call(|| tx.commit()) {
-                    Ok(_) => state.model = model.into(),
+                    Ok(_) => {
+                        let state_model = Rc::make_mut(&mut state.model);
+                        for (k, v) in &model {
+                            if starting.get(&k) != Some(&v) {
+                                state_model.insert(k.clone(), v.clone());
+                            }
+                        }
+                        for k in starting.keys() {
+                            if !model.contains_key(&k) {
+                                state_model.remove(k);
+                            }
+                        }
+                    },
                     Err(e) => error!("commit failed: {e}"),
                 }
-                if state.always_validate || tx_id % 8 == 0 {
-                    match state.db.validate_free_space() {
-                        Ok(()) | Err(Error::DatabaseHalted) => (),
-                        Err(e) => panic!("{e}"),
-                    }
-                }
-                state.writter = None;
+                Self::validate(state, &state.model, &state.db.begin_read().unwrap());
+                // if state.always_validate || tx_id % 8 == 0 {
+                //     match state.db.validate_free_space() {
+                //         Ok(()) | Err(Error::DatabaseHalted) => (),
+                //         Err(e) => panic!("{e}"),
+                //     }
+                // }
+                state.writers.remove(&self.id);
                 if !self.op_queue.is_empty() {
                     self.enqueued = true;
                     state.read_queue.push_back(self.id);
@@ -312,13 +323,13 @@ impl Actor {
                 Self::validate(state, &model, &rx);
                 false
             }
-            Tx::Write(model, tx) => {
+            Tx::Write(model, tx, ..) => {
                 trace!("rolling back {}", tx.tx_id());
                 Self::validate(state, &model, &tx);
                 if let Err(e) = failure.call(|| tx.rollback()) {
                     error!("rollback failed: {e}");
                 }
-                state.writter = None;
+                state.writers.remove(&self.id);
                 if !self.op_queue.is_empty() {
                     self.enqueued = true;
                     state.read_queue.push_back(self.id);
@@ -329,7 +340,7 @@ impl Actor {
     }
 
     fn checkpoint(&mut self, state: &mut WorldState, op: Op) -> bool {
-        if state.writter.is_none() {
+        if state.writers.is_empty() {
             if let Err(e) = op.failure().call(|| state.db.checkpoint()) {
                 error!("checkpoint failed: {e}");
             }
@@ -363,13 +374,13 @@ impl Actor {
         }
         match &mut self.tx {
             Tx::None => {
-                if state.writter.is_none() {
+                if state.writers.len() < MAX_WRITERS {
                     match state.db.begin_write() {
-                        Ok(tx) => self.tx = Tx::Write((*state.model).clone(), tx),
+                        Ok(tx) => self.tx = Tx::Write((*state.model).clone(), tx, state.model.clone()),
                         Err(Error::DatabaseHalted) => return false,
                         Err(e) => panic!("{e}"),
                     }
-                    state.writter = Some(self.id);
+                    state.writers.insert(self.id);
                 } else {
                     if !self.enqueued {
                         self.enqueued = true;
@@ -380,11 +391,11 @@ impl Actor {
                 }
             }
             Tx::Read(_, _) => unreachable!(),
-            Tx::Write(_, _) => (),
+            Tx::Write(..) => (),
         }
         match &mut self.tx {
             Tx::None | Tx::Read(_, _) => unreachable!(),
-            Tx::Write(model, tx) => {
+            Tx::Write(model, tx, ..) => {
                 let mut tree = match tx.get_or_create_tree(b"default") {
                     Ok(tree) => tree,
                     Err(Error::TransactionAborted) => return false,
@@ -449,9 +460,9 @@ impl Actor {
                     }
                 }
                 drop(tree);
-                if state.always_validate {
-                    Self::validate(state, &model, tx);
-                }
+                // if state.always_validate {
+                //     Self::validate(state, &model, tx);
+                // }
                 false
             }
         }
@@ -507,6 +518,7 @@ impl Actor {
                 assert_eq!(mv, v1.as_ref());
                 assert!(range.next().is_none());
             }
+            assert_eq!(tree.len() as usize, model.len());
         }
         if val_forw {
             let mut iter = tree.iter().unwrap();
@@ -515,7 +527,7 @@ impl Actor {
                 assert_eq!(k.0.as_slice(), ck.as_ref());
                 assert_eq!(v.0.as_slice(), cv.as_ref());
             }
-            assert!(iter.next().is_none());
+            assert_eq!(iter.next().map(|r| r.ok()), None);
         }
         if val_back {
             let mut iter = tree.iter().unwrap().rev();
@@ -524,7 +536,7 @@ impl Actor {
                 assert_eq!(k.0.as_slice(), ck.as_ref());
                 assert_eq!(v.0.as_slice(), cv.as_ref());
             }
-            assert!(iter.next().is_none());
+            assert_eq!(iter.next().map(|r| r.ok()), None);
         }
     }
 }
@@ -538,7 +550,7 @@ fuzz_target!(|ops: Vec<Op>| {
     db_options.checkpoint_interval = std::time::Duration::MAX;
     db_options.use_wal = cfg!(feature = "failpoints");
     db_options.default_commit_sync = false;
-    db_options.checkpoint_target_size = 16 * 4096 as usize;
+    // db_options.checkpoint_target_size = 16 * 4096 as usize;
     let always_validate =
         std::env::var("ALWAYS_VALIDATE").map_or(0, |s| s.parse::<i64>().unwrap()) != 0;
     let db = canopydb::Database::with_options(options.clone(), db_options.clone()).unwrap();
@@ -548,7 +560,7 @@ fuzz_target!(|ops: Vec<Op>| {
             model: Default::default(),
             write_queue: Default::default(),
             read_queue: Default::default(),
-            writter: None,
+            writers: Default::default(),
             always_validate,
         },
         actors: Default::default(),
@@ -558,38 +570,40 @@ fuzz_target!(|ops: Vec<Op>| {
     }
     dbg!(ops.len());
     for op in ops {
-        world.actors[op.actor().0].op(&mut world.state, Some(op));
+        let actor_no = op.actor().0;
+        world.actors[actor_no].op_queue.push_back(op);
+        world.actors[actor_no].op(&mut world.state);
         while !world.state.read_queue.is_empty()
-            || (world.state.writter.is_none() && !world.state.write_queue.is_empty())
+            || (world.state.writers.is_empty() && !world.state.write_queue.is_empty())
         {
-            if world.state.writter.is_none() {
+            if world.state.writers.is_empty() {
                 if let Some(next) = world.state.write_queue.pop_front() {
                     world.actors[next.0].enqueued = false;
-                    world.actors[next.0].op(&mut world.state, None);
+                    world.actors[next.0].op(&mut world.state);
                 }
             }
             if let Some(next) = world.state.read_queue.pop_front() {
                 world.actors[next.0].enqueued = false;
-                world.actors[next.0].op(&mut world.state, None);
+                world.actors[next.0].op(&mut world.state);
             }
         }
     }
     while !world.state.read_queue.is_empty() || !world.state.write_queue.is_empty() {
-        if world.state.writter.is_none() {
+        if world.state.writers.is_empty() {
             if let Some(next) = world.state.write_queue.pop_front() {
                 world.actors[next.0].enqueued = false;
-                world.actors[next.0].op(&mut world.state, None);
+                world.actors[next.0].op(&mut world.state);
             }
         }
         if let Some(next) = world.state.read_queue.pop_front() {
             world.actors[next.0].enqueued = false;
-            world.actors[next.0].op(&mut world.state, None);
+            world.actors[next.0].op(&mut world.state);
         }
         if world.state.read_queue.is_empty()
             && !world.state.write_queue.is_empty()
-            && world.state.writter.is_some()
+            && !world.state.writers.is_empty()
         {
-            assert!(world.actors[world.state.writter.take().unwrap().0]
+            assert!(world.actors[world.state.writers.pop_first().unwrap().0]
                 .commit(&mut world.state, Failure::default()));
         }
     }
@@ -610,7 +624,7 @@ fuzz_target!(|ops: Vec<Op>| {
             model: Default::default(),
             write_queue: Default::default(),
             read_queue: Default::default(),
-            writter: None,
+            writers: Default::default(),
             always_validate,
         },
         actors: Default::default(),

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -174,6 +174,7 @@ impl Allocator {
     }
 
     pub fn reserve_from_main(&mut self, mut span: PageId, bulk: bool) -> Result<(), Error> {
+        trace!("reserve_from_main span {span} bulk {bulk:?}");
         self.main_bulk_reservations += bulk as u64;
         if bulk {
             span = span.max(

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -61,7 +61,6 @@ pub(crate) struct Allocator {
 
 impl MainAllocator {
     pub fn truncate_end(&mut self) -> Result<(), Error> {
-        return Ok(());
         let mut returned = 0;
         let free = self.free.merged()?;
         while let Some((page, span)) = free.last_piece() {
@@ -128,7 +127,7 @@ impl Allocator {
     const INITIAL_ALLOC: PageId = 100;
     const ALLOCATION_BATCH: PageId = 100;
 
-    pub fn new_transaction(inner: &DatabaseInner, multi: bool) -> Result<Allocator, Error> {
+    pub fn new_transaction(inner: &DatabaseInner) -> Result<Allocator, Error> {
         let mut result = Self {
             is_checkpointer: false,
             main: Some(inner.allocator.clone()),

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -9,7 +9,7 @@ use crate::{
     freelist::Freelist,
     repr::{PageId, FIRST_COMPRESSED_PAGE},
     shim::parking_lot::Mutex,
-    DatabaseInner, FreePage, PAGE_SIZE,
+    DatabaseInner, DeferredFreelist, FreePage, PAGE_SIZE,
 };
 
 use triomphe::Arc;
@@ -18,15 +18,14 @@ use zerocopy::AsBytes;
 #[derive(Debug, Default)]
 pub(crate) struct MainAllocator {
     /// Free Page Ids
-    pub free: Freelist,
-    pub unmerged_free: Vec<Freelist>,
+    pub free: DeferredFreelist,
     /// Free Indirection Page Ids
-    pub indirection_free: Freelist,
+    pub indirection_free: DeferredFreelist,
     /// Page Ids freed from the current snapshot (metapage.snapshot_tx_id)
     /// Will be merged w/ free once the is no longer required
-    pub snapshot_free: Freelist,
+    pub snapshot_free: DeferredFreelist,
     /// Same as above, but for the ongoing checkpoint (state.ongoing_snapshot_tx_id)
-    pub next_snapshot_free: Freelist,
+    pub next_snapshot_free: DeferredFreelist,
     /// Allocation horizons
     pub next_page_id: PageId,
     pub next_indirection_id: PageId,
@@ -61,19 +60,13 @@ pub(crate) struct Allocator {
 }
 
 impl MainAllocator {
-    pub fn merge_unmerged_free(&mut self) {
-        let mut free = mem::take(&mut self.free);
-        for f in self.unmerged_free.drain(..) {
-            free.merge(&f).unwrap();
-        }
-        self.free = free;
-    }
-
-    pub fn truncate_end(&mut self) {
+    pub fn truncate_end(&mut self) -> Result<(), Error> {
+        return Ok(());
         let mut returned = 0;
-        while let Some((page, span)) = self.free.last_piece() {
+        let free = self.free.merged()?;
+        while let Some((page, span)) = free.last_piece() {
             if page + span == self.next_page_id {
-                assert_eq!(self.free.allocate_last_piece(), Some((page, span)));
+                assert_eq!(free.allocate_last_piece(), Some((page, span)));
                 self.next_page_id -= span;
                 returned += span;
             } else {
@@ -81,9 +74,10 @@ impl MainAllocator {
             }
         }
         let mut returned_ind = 0;
-        while let Some((page, span)) = self.indirection_free.last_piece() {
+        let indirection_free = self.indirection_free.merged()?;
+        while let Some((page, span)) = indirection_free.last_piece() {
             if page + span == self.next_indirection_id {
-                let last_piece = self.indirection_free.allocate_last_piece();
+                let last_piece = indirection_free.allocate_last_piece();
                 debug_assert_eq!(last_piece, Some((page, span)));
                 self.next_indirection_id -= span;
                 returned_ind += span;
@@ -94,6 +88,7 @@ impl MainAllocator {
         if returned != 0 || returned_ind != 0 {
             trace!("Returned {returned} to next_id {returned_ind} pages to next_indirection_id");
         }
+        Ok(())
     }
 
     pub fn from_bytes(mut data: &[u8]) -> Result<Self, Error> {
@@ -110,8 +105,8 @@ impl MainAllocator {
             let (fl, read_len) = Freelist::deserialize(data)?;
             data = &data[read_len..];
             let (left, right) = fl.split(FIRST_COMPRESSED_PAGE);
-            result.free.merge(&left)?;
-            result.indirection_free.merge(&right)?;
+            result.free.merged()?.merge(&left)?;
+            result.indirection_free.merged()?.merge(&right)?;
         }
 
         Ok(result)
@@ -121,16 +116,16 @@ impl MainAllocator {
         size_of::<PageId>() // next_page_id
         + size_of::<PageId>() // next_indirection_id
         + size_of::<u8>() // num freelists
-        + self.free.serialized_size()
-        + self.unmerged_free.iter().map(Freelist::serialized_size).sum::<usize>()
-        + self.indirection_free.serialized_size()
-        + self.snapshot_free.serialized_size()
-        + self.next_snapshot_free.serialized_size()
+        + self.free.max_serialized_size()
+        + self.indirection_free.max_serialized_size()
+        + self.snapshot_free.max_serialized_size()
+        + self.next_snapshot_free.max_serialized_size()
     }
 }
 
 impl Allocator {
-    const MULTI_W_INITIAL_ALLOC: PageId = 10;
+    const MULTI_W_INITIAL_ALLOC_MIN: PageId = 5;
+    const MULTI_W_INITIAL_ALLOC: PageId = 15;
     const ALLOCATION_BATCH: PageId = 100;
 
     pub fn new_transaction(inner: &DatabaseInner, multi: bool) -> Result<Allocator, Error> {
@@ -143,22 +138,24 @@ impl Allocator {
         result.main_next_page_id = main.next_page_id;
         result.main_next_indirection_id = main.next_indirection_id;
         if multi {
-            if let Some(some) = main.unmerged_free.pop() {
-                result.free = some;
-            } else {
-                result.free = main.free.bulk_allocate(Self::MULTI_W_INITIAL_ALLOC, true);
-            }
+            result.free = main.free.bulk_allocate(
+                Self::MULTI_W_INITIAL_ALLOC_MIN,
+                Self::MULTI_W_INITIAL_ALLOC,
+                true,
+            )?;
         } else {
-            main.merge_unmerged_free();
-            let is_checkpointing = inner.checkpoint_lock.is_locked();
-            if is_checkpointing {
-                let bulk_span = (main.free.len() / 2)
-                    .min((inner.opts.checkpoint_target_size / PAGE_SIZE as usize) as PageId);
-                result.free = main.free.bulk_allocate(bulk_span, false);
-            } else {
-                mem::swap(&mut result.free, &mut main.free);
-            }
+            // let is_checkpointing = inner.checkpoint_lock.is_locked();
+            // if is_checkpointing {
+                result.free = main.free.bulk_allocate(
+                    Self::MULTI_W_INITIAL_ALLOC_MIN,
+                    Self::MULTI_W_INITIAL_ALLOC,
+                    true,
+                )?;
+            // } else {
+            //     mem::swap(&mut result.free, main.free.merged()?);
+            // }
         }
+        drop(main);
         result.all_allocations.merge(&result.free)?;
         Ok(result)
     }
@@ -172,13 +169,14 @@ impl Allocator {
         let mut main = inner.allocator.lock();
         result.main_next_page_id = main.next_page_id;
         result.main_next_indirection_id = main.next_indirection_id;
-        result.indirection_free = main.indirection_free.clone();
+        result.indirection_free = main.indirection_free.merged()?.clone();
         // Whatever is left in free goes into externally_allocated and we won't be able to use
         // it anymore. If reserve_from_global_state is required later it'll have to remove
         // from externally_allocated to make sure pages aren't duplicated.
-        main.merge_unmerged_free();
-        result.externally_allocated.merge(&main.free)?;
-        result.externally_allocated.merge(&main.snapshot_free)?;
+        result.externally_allocated.merge(main.free.merged()?)?;
+        result
+            .externally_allocated
+            .merge(main.snapshot_free.merged()?)?;
         // next_snapshot_free can only grow while a checkpointer is running
         assert!(main.next_snapshot_free.is_empty());
         let old_snapshots = inner.old_snapshots.lock();
@@ -199,8 +197,6 @@ impl Allocator {
             );
         }
         let mut main = self.main.as_ref().unwrap().lock();
-        main.merge_unmerged_free();
-
         if self.is_checkpointer {
             match self.main_next_page_id.cmp(&main.next_page_id) {
                 Ordering::Equal => (),
@@ -220,14 +216,14 @@ impl Allocator {
         }
 
         if bulk {
-            let reserved = main.free.bulk_allocate(span, true);
+            let reserved = main.free.bulk_allocate(span, span, true)?;
             self.all_allocations.merge(&reserved)?;
             self.free.merge(&reserved)?;
             if self.is_checkpointer {
                 self.externally_allocated.subtract(&reserved);
             }
-            span -= reserved.len();
-        } else if let Some(allocation) = main.free.allocate(span) {
+            span = span.saturating_sub(reserved.len());
+        } else if let Some(allocation) = main.free.merged()?.allocate(span) {
             self.all_allocations.free(allocation, span)?;
             self.free.free(allocation, span)?;
             if self.is_checkpointer {
@@ -277,9 +273,10 @@ impl Allocator {
     fn reserve_indirections_from_main(&mut self) -> Result<(), Error> {
         let mut main = self.main.as_ref().unwrap().lock();
         if !main.indirection_free.is_empty() {
-            self.all_allocations.merge(&main.indirection_free)?;
-            self.indirection_free.merge(&main.indirection_free)?;
-            main.indirection_free.clear();
+            // TODO: fix for multi-writers
+            self.all_allocations
+                .merge(main.indirection_free.merged()?)?;
+            self.indirection_free = mem::take(main.indirection_free.merged()?);
         } else {
             const MIN_ALLOCATION: PageId = 100;
             let left = PageId::MAX - main.next_indirection_id;
@@ -317,22 +314,25 @@ impl Allocator {
 
     pub fn commit(&mut self) -> Result<(), Error> {
         let mut main = self.main.as_ref().unwrap().lock();
-        main.unmerged_free.push(mem::take(&mut self.free));
+        main.free.append(mem::take(&mut self.free))?;
         // indirection_free from the ckp allocator is a copy
         // of main allocator indirection_free when it was created.
         if !self.is_checkpointer {
-            main.indirection_free.merge(&self.indirection_free)?;
+            main.indirection_free
+                .append(mem::take(&mut self.indirection_free))?;
         }
-        main.snapshot_free.merge(&self.snapshot_free)?;
-        main.next_snapshot_free.merge(&self.next_snapshot_free)?;
+        main.snapshot_free
+            .append(mem::take(&mut self.snapshot_free))?;
+        main.next_snapshot_free
+            .append(mem::take(&mut self.next_snapshot_free))?;
         Ok(())
     }
 
     pub fn rollback(&mut self) -> Result<(), Error> {
         let mut main = self.main.as_ref().unwrap().lock();
         let indirect_allocations = self.all_allocations.split_off(FIRST_COMPRESSED_PAGE);
-        main.free.merge(&self.all_allocations)?;
-        main.indirection_free.merge(&indirect_allocations)?;
+        main.free.append(mem::take(&mut self.all_allocations))?;
+        main.indirection_free.append(indirect_allocations)?;
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     EnvironmentLocked,
     WriteTransactionRequired,
     CantCompact,
+    WriteConflict,
 }
 
 impl Error {
@@ -57,6 +58,7 @@ impl Error {
             Self::EnvironmentLocked => Self::EnvironmentLocked,
             Self::WriteTransactionRequired => Self::WriteTransactionRequired,
             Self::CantCompact => Self::CantCompact,
+            Self::WriteConflict => Self::WriteConflict,
         }
     }
 }

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -610,7 +610,7 @@ impl Shard {
         }
         self.len = 0;
         self.hist.0.fill(0);
-        let ranges = Arc::make_mut(&mut self.ranges);
+        let ranges = range_vec_make_mut(&mut self.ranges, 0);
         let this_ranges = mem::take(ranges)
             .into_iter()
             .map(|r| r.page()..r.page_end());

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -48,7 +48,7 @@ impl DeferredFreelist {
         bulk_span: PageId,
         precise: bool,
     ) -> Result<Freelist, Error> {
-        if self.deferred.last().map_or(false, |f| f.len() >= min_span) {
+        if self.deferred.last().is_some_and(|f| f.len() >= min_span) {
             return Ok(self.deferred.pop().unwrap());
         }
         Ok(self.merged()?.bulk_allocate(bulk_span, precise))
@@ -569,7 +569,7 @@ impl Shard {
         if self
             .ranges
             .first()
-            .map_or(true, |r| self.base + r.page_end() <= right_gte)
+            .is_none_or(|r| self.base + r.page_end() <= right_gte)
         {
             return other;
         }
@@ -684,7 +684,7 @@ impl Freelist {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.shards.as_ref().map_or(true, |s| s.is_empty())
+        self.shards.as_ref().is_none_or(|s| s.is_empty())
     }
 
     pub fn len(&self) -> PageId {
@@ -987,7 +987,7 @@ impl Freelist {
     fn validate(&self) -> bool {
         self.shards
             .as_ref()
-            .map_or(true, |s| s.iter().all(|s| s.validate() && !s.is_empty()))
+            .is_none_or(|s| s.iter().all(|s| s.validate() && !s.is_empty()))
     }
 }
 

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -54,11 +54,10 @@ impl DeferredFreelist {
         Ok(self.merged()?.bulk_allocate(bulk_span, precise))
     }
 
-    pub fn append(&mut self, other: Freelist) -> Result<(), Error> {
+    pub fn append(&mut self, other: Freelist) {
         if !other.is_empty() {
             self.deferred.push(other);
         }
-        Ok(())
     }
 
     pub fn into_merged(mut self) -> Result<Freelist, Error> {

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -55,10 +55,11 @@ impl DeferredFreelist {
     }
 
     pub fn append(&mut self, other: Freelist) -> Result<(), Error> {
-        if !other.is_empty() {
-            self.deferred.push(other);
-        }
-        Ok(())
+        // if !other.is_empty() {
+        //     self.deferred.push(other);
+        // }
+        // Ok(())
+        self.freelist.merge(&other)
     }
 
     pub fn into_merged(mut self) -> Result<Freelist, Error> {
@@ -85,6 +86,7 @@ impl DeferredFreelist {
         self.freelist.is_empty() && self.deferred.is_empty()
     }
 
+    #[cfg(test)]
     pub fn len(&self) -> PageId {
         self.freelist.len() + self.deferred.iter().map(Freelist::len).sum::<PageId>()
     }

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -55,11 +55,10 @@ impl DeferredFreelist {
     }
 
     pub fn append(&mut self, other: Freelist) -> Result<(), Error> {
-        // if !other.is_empty() {
-        //     self.deferred.push(other);
-        // }
-        // Ok(())
-        self.freelist.merge(&other)
+        if !other.is_empty() {
+            self.deferred.push(other);
+        }
+        Ok(())
     }
 
     pub fn into_merged(mut self) -> Result<Freelist, Error> {

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -915,6 +915,7 @@ impl Freelist {
                     if shard.is_empty() {
                         shards.remove(i);
                     }
+                    #[cfg(debug_assertions)]
                     debug_assert_eq!(len_before - span, self.len());
                     result = Some(p);
                     break;
@@ -928,6 +929,7 @@ impl Freelist {
         } else {
             result = Self::allocate_cross_shard(shards, span, 0..shards.len());
         }
+        #[cfg(debug_assertions)]
         debug_assert_eq!(len_before - result.map_or(0, |_| span), self.len());
         #[cfg(any(test, fuzzing))]
         debug_assert!(self.validate());
@@ -956,6 +958,7 @@ impl Freelist {
             span -= span_for_shard;
             page_id += span_for_shard;
         }
+        #[cfg(debug_assertions)]
         debug_assert_eq!(len_before - self.len(), removed);
         removed
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,11 @@ use TransactionFlags as TF;
 /// Applications utilizing this often require wraping write transaction blocks in a loop and retry
 /// the transaction if [`WriteTransaction::commit`] returns [`Error::WriteConflict`].
 ///
-/// The implementation detects write-write conflicts at the page level granularity so there could
-/// be "false" conflicts in case mutated keys fall within the same Leaf page. This is equivalent
-/// to Snapshot-Isolation (SI). Note the this isn't _Serializable_-Snapshot-Isolation (SSI) as
+/// These transactions provide Snapshot-Isolation (SI) instead of _Serializable_-Snapshot-Isolation (SSI) as
 /// Write-Skew anomalies can still happen.
+///
+/// Note that the implementation detects write-write conflicts at the page level granularity so there could
+/// be "false" conflicts in case mutated keys fall within the same Leaf page.
 ///
 /// While concurrent write transactions have more individual overhead than exclusive write
 /// transactions, they might be useful in cases like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl DatabaseFile {
             .mmap
             .read()
             .as_ref()
-            .map_or(false, |m| m.len() as u64 >= file_len)
+            .is_some_and(|m| m.len() as u64 >= file_len)
         {
             return Ok(());
         }
@@ -1945,7 +1945,7 @@ impl Transaction {
                 // buffer free handled by checkpointer
                 debug_assert!(r_latest);
                 debug_assert!(page_id.is_compressed());
-                let target = if ongoing_snapshot_tx_id.map_or(false, |ockp| from <= ockp) {
+                let target = if ongoing_snapshot_tx_id.is_some_and(|ockp| from <= ockp) {
                     &mut allocator.next_snapshot_free
                 } else {
                     &mut allocator.snapshot_free
@@ -3264,7 +3264,7 @@ impl DatabaseInner {
             }
             CheckpointReason::WalSize(min_wal_tail) => {
                 let cur_wal_tail = inner.wal_tail();
-                if cur_wal_tail.map_or(true, |w| w > min_wal_tail) {
+                if cur_wal_tail.is_none_or(|w| w > min_wal_tail) {
                     debug!("Ignoring checkpoint request {reason:?}, tail is {cur_wal_tail:?}");
                     return Ok(0);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1387,6 +1387,9 @@ impl Drop for Transaction {
                     .try_lock()
                     .map(|state| state.metapage.tx_id)
             });
+            if earliest_open_read_tx.is_none() {
+                self.inner.transactions_condvar.notify_all();
+            }
             drop(transactions);
 
             match earliest_tx_needed {
@@ -1399,9 +1402,6 @@ impl Drop for Transaction {
                     free_buffers.scan_from = free_buffers.scan_from.min(tx_id);
                 }
                 _ => (),
-            }
-            if earliest_open_read_tx.is_none() {
-                self.inner.transactions_condvar.notify_all();
             }
         }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -379,7 +379,6 @@ impl TreeOptions {
             fixed_value_len: self.fixed_value_len,
             level: 0,
             num_keys: 0,
-            key_delta: 0,
             nodes_compressed,
             overflow_compressed,
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -379,6 +379,7 @@ impl TreeOptions {
             fixed_value_len: self.fixed_value_len,
             level: 0,
             num_keys: 0,
+            key_delta: 0,
             nodes_compressed,
             overflow_compressed,
         }

--- a/src/pagetable.rs
+++ b/src/pagetable.rs
@@ -244,9 +244,9 @@ impl PageTable {
         self.peek(tx_id, page_id, |from, item| Some((from, item.to_item()?)))
     }
 
-    pub fn is_latest_page(&self, tx_id: TxId, page_id: PageId) -> bool {
+    pub fn is_latest_from_lte(&self, tx_id: TxId, page_id: PageId) -> bool {
         if let Some(values) = self.table.get(&page_id) {
-            values.last().map_or(true, |&(from, _)| from < tx_id)
+            values.last().map_or(true, |&(from, _)| from <= tx_id)
         } else {
             true
         }

--- a/src/pagetable.rs
+++ b/src/pagetable.rs
@@ -252,6 +252,7 @@ impl PageTable {
     }
 
     pub fn is_latest_from_lte(&self, tx_id: TxId, page_id: PageId) -> bool {
+        trace!("is_latest_from_lte tx_id {tx_id} page {page_id}");
         if let Some(values) = self.table.get(&page_id) {
             values.last().map_or(true, |&(from, _)| from <= tx_id)
         } else {

--- a/src/pagetable.rs
+++ b/src/pagetable.rs
@@ -254,7 +254,7 @@ impl PageTable {
     pub fn is_latest_from_lte(&self, tx_id: TxId, page_id: PageId) -> bool {
         trace!("is_latest_from_lte tx_id {tx_id} page {page_id}");
         if let Some(values) = self.table.get(&page_id) {
-            values.last().map_or(true, |&(from, _)| from <= tx_id)
+            values.last().is_none_or(|&(from, _)| from <= tx_id)
         } else {
             true
         }
@@ -318,7 +318,7 @@ impl PageTable {
         let mut drop_list = SmallVec::<InnerItem, 20>::new();
         self.table.retain(|_page_id, values| {
             debug_assert!(values.last().unwrap().0 <= tx_id);
-            if values.last().map_or(false, |(i, _)| i == &tx_id) {
+            if values.last().is_some_and(|(i, _)| i == &tx_id) {
                 let (_, pop) = values.pop().unwrap();
                 drop_list.push(pop);
                 !values.is_empty()

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -262,13 +262,10 @@ pub struct TreeValue {
 
 impl std::fmt::Debug for TreeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let id = self.id;
-        let root = self.root;
-        let num_keys = self.num_keys;
         f.debug_struct("TreeValue")
-            .field("id", &id)
-            .field("root", &root)
-            .field("num_keys", &num_keys)
+            .field("id", &{ self.id })
+            .field("root", &{ self.root })
+            .field("num_keys", &{ self.num_keys })
             .field("nodes_compressed", &self.nodes_compressed)
             .field("overflow_compressed", &self.overflow_compressed)
             .field("min_branch_node_pages", &self.min_branch_node_pages)

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -266,6 +266,7 @@ impl std::fmt::Debug for TreeValue {
             .field("id", &{ self.id })
             .field("root", &{ self.root })
             .field("num_keys", &{ self.num_keys })
+            .field("key_delta", &{ self.key_delta })
             .field("nodes_compressed", &self.nodes_compressed)
             .field("overflow_compressed", &self.overflow_compressed)
             .field("min_branch_node_pages", &self.min_branch_node_pages)

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -8,7 +8,7 @@ use zerocopy::*;
 use crate::{node::NodeType, utils::EscapedBytes, PAGE_SIZE};
 
 pub type DbId = u128;
-pub type TreeId = u64;
+pub type TreeId = u128;
 pub type TxId = u64;
 pub type PageId = u32;
 pub type WalIdx = u64;
@@ -209,7 +209,6 @@ pub struct MetapageHeader {
     /// Last WalIdx part of the snapshot (exclusive)
     pub wal_end: WalIdx,
     pub snapshot_tx_id: TxId,
-    pub next_tree_id: TreeId,
     pub trees_tree: TreeValue,
     pub _padding1: u8,
     pub indirections_tree: TreeValue,
@@ -251,6 +250,7 @@ pub struct TreeValue {
     pub id: TreeId,
     pub root: PageId,
     pub num_keys: u64,
+    pub key_delta: i64,
     pub level: u8,
     pub min_branch_node_pages: u8,
     pub min_leaf_node_pages: u8,

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -250,7 +250,6 @@ pub struct TreeValue {
     pub id: TreeId,
     pub root: PageId,
     pub num_keys: u64,
-    pub key_delta: i64,
     pub level: u8,
     pub min_branch_node_pages: u8,
     pub min_leaf_node_pages: u8,
@@ -266,7 +265,6 @@ impl std::fmt::Debug for TreeValue {
             .field("id", &{ self.id })
             .field("root", &{ self.root })
             .field("num_keys", &{ self.num_keys })
-            .field("key_delta", &{ self.key_delta })
             .field("nodes_compressed", &self.nodes_compressed)
             .field("overflow_compressed", &self.overflow_compressed)
             .field("min_branch_node_pages", &self.min_branch_node_pages)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -574,7 +574,7 @@ fn multi_writer() {
     let env = Environment::with_options(options).unwrap();
 
     let db1 = env.get_or_create_database("db1").unwrap();
-    let tx1 = db1.begin_write().unwrap();
+    let tx1 = db1.begin_write_with(true).unwrap();
     let mut tree1 = tx1.get_or_create_tree(b"my_tree").unwrap();
     for i in 0..200 {
         tree1.insert(format!("foo{i}").as_bytes(), b"bar").unwrap();
@@ -582,8 +582,8 @@ fn multi_writer() {
     drop(tree1);
     tx1.commit().unwrap();
     // Each database unique write transaction is independent.
-    let tx1 = db1.begin_write().unwrap();
-    let tx2 = db1.begin_write().unwrap();
+    let tx1 = db1.begin_write_with(true).unwrap();
+    let tx2 = db1.begin_write_with(true).unwrap();
     let mut tree1 = tx1.get_or_create_tree(b"my_tree").unwrap();
     let mut tree2 = tx2.get_or_create_tree(b"my_tree").unwrap();
     tree1.insert(b"foo0", b"bar").unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1098,8 +1098,7 @@ fn recover_then_checkpoint() {
             tree.insert(k.as_bytes(), v.as_bytes()).unwrap();
         }
         drop(tree);
-        latest_tx_id = tx.tx_id();
-        tx.commit().unwrap();
+        latest_tx_id = tx.commit().unwrap();
         master_sample.extend(sample.into_iter());
     }
 
@@ -1164,8 +1163,7 @@ fn recovery() {
             tree.insert(k.as_bytes(), v.as_bytes()).unwrap();
         }
         drop(tree);
-        latest_tx_id = tx.tx_id();
-        tx.commit().unwrap();
+        latest_tx_id = tx.commit().unwrap();
         master_sample.extend(sample.into_iter());
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -684,10 +684,7 @@ fn delete_works() {
                 let deleted = tree.delete(k.as_bytes()).unwrap();
                 assert!(deleted);
             }
-
-            let mut cursor = tree.cursor();
-            assert!(!cursor.first().unwrap());
-            drop(cursor);
+            assert!(tree.keys().unwrap().next().is_none());
             assert_eq!(tree.len(), 0);
         } else if _round_no % 100 == 0 {
             for k in master_sample
@@ -724,9 +721,7 @@ fn delete_works() {
         let deleted = tree.delete(k.as_bytes()).unwrap();
         assert!(deleted);
     }
-    let mut cursor = tree.cursor();
-    assert!(!cursor.first().unwrap());
-    drop(cursor);
+    assert!(tree.keys().unwrap().next().is_none());
     assert_eq!(tree.len(), 0);
     drop(tree);
     tx.commit().unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -84,8 +84,8 @@ pub struct Tree<'tx> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum TreeState {
     Available { value: TreeValue, dirty: bool },
-    Deleted,
     InUse { value: TreeValue },
+    Deleted,
 }
 
 enum MutateResult {
@@ -168,6 +168,7 @@ impl<'tx> Tree<'tx> {
             Ordering::Greater => self.value.num_keys += delta as u64,
             Ordering::Equal => return,
         }
+        self.value.key_delta += delta;
         self.dirty = true;
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1118,6 +1118,9 @@ fn node_split_right<TYPE: NodeRepr>(
             tree.allocate_node(right_size, Some(node.header().level))?,
         );
         right.as_dirty().set_key_prefix(&right_prefix);
+        if tree.tx.is_multi_write_tx() {
+            tree.tx.make_dirty(node)?;
+        }
         return Ok((false, full_separator, right));
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -479,7 +479,7 @@ impl<'tx> Tree<'tx> {
             ));
         }
         if self.value.fixed_value_len >= 0 {
-            if value.map_or(false, |v| v.len() != self.value.fixed_value_len as usize) {
+            if value.is_some_and(|v| v.len() != self.value.fixed_value_len as usize) {
                 return Err(error_validation!(
                     "Tree only accepts values of length {}",
                     self.value.fixed_value_len

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -633,7 +633,7 @@ impl<'tx> Tree<'tx> {
             match Self::insert_kv(tree, prefix, &mut node, search, full_key, value)? {
                 Ok(()) => {
                     trace!(
-                        "inserted {:?} in leaf {} {:?}, num_keys {}",
+                        "inserted `{:?}` in leaf {} {:?}, num_keys {}",
                         &EscapedBytes(full_key),
                         node.id(),
                         search,
@@ -649,7 +649,7 @@ impl<'tx> Tree<'tx> {
         } else if let Ok(idx) = search {
             tree.inc_num_keys(-1);
             trace!(
-                "delete {:?} in leaf {} pos {:?}",
+                "delete `{:?}` in leaf {} pos {:?}",
                 &EscapedBytes(full_key),
                 node.id(),
                 search

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -556,7 +556,6 @@ impl std::fmt::Debug for ByteSize {
 
 pub trait CellExt<T> {
     fn reset<F: FnOnce(T) -> T>(&self, f: F);
-    fn reset_with<F: FnOnce(&mut T)>(&self, f: F);
 }
 
 impl<T: Copy> CellExt<T> for std::cell::Cell<T> {
@@ -564,13 +563,6 @@ impl<T: Copy> CellExt<T> for std::cell::Cell<T> {
     fn reset<F: FnOnce(T) -> T>(&self, f: F) {
         let mut v = self.get();
         v = f(v);
-        self.set(v);
-    }
-
-    #[inline]
-    fn reset_with<F: FnOnce(&mut T)>(&self, f: F) {
-        let mut v = self.get();
-        f(&mut v);
         self.set(v);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -511,7 +511,7 @@ impl<T> WaitJoinHandle<T> {
     }
 }
 
-#[derive(Display)]
+#[derive(Display, PartialEq, Eq)]
 #[display("{:?}", self)]
 /// Outputs bytes as escaped ascii strings
 pub struct EscapedBytes<'a>(pub &'a [u8]);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -422,7 +422,7 @@ impl Trap {
     }
 }
 
-impl<'a> TrapGuard<'a> {
+impl TrapGuard<'_> {
     #[inline]
     pub fn disarm(mut self) {
         debug_assert!(self.0.is_some());
@@ -430,7 +430,7 @@ impl<'a> TrapGuard<'a> {
     }
 }
 
-impl<'a> Drop for TrapGuard<'a> {
+impl Drop for TrapGuard<'_> {
     #[inline]
     fn drop(&mut self) {
         if let Some(arc) = &self.0 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -534,6 +534,7 @@ impl std::fmt::Debug for EscapedBytes<'_> {
         Ok(())
     }
 }
+
 #[derive(Display)]
 #[display("{:?}", self)]
 /// Outputs bytes sizes as human sizes

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -843,7 +843,7 @@ impl Wal {
             if files_to_delete
                 .last()
                 .zip(files.last_key_value())
-                .map_or(false, |((l_d, _), (&l_f, _))| l_d.start == l_f)
+                .is_some_and(|((l_d, _), (&l_f, _))| l_d.start == l_f)
             {
                 let next_idx = files_to_delete.last().unwrap().0.end;
                 let wal_file = self.create_new_file(next_idx)?;

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::{
     repr::{DbId, TreeId},
+    utils::EscapedBytes,
     EnvOptions, TreeOptions,
 };
 
@@ -41,11 +42,17 @@ mod op_bytes {
 #[derive(Debug)]
 pub enum Operation {
     Database(DbId),
+    #[debug("Insert({_0}, {}, {})", EscapedBytes(&_1), EscapedBytes(&_2))]
     Insert(TreeId, Vec<u8>, Vec<u8>),
+    #[debug("Delete({_0}, {})", EscapedBytes(&_1))]
     Delete(TreeId, Vec<u8>),
+    #[debug("DeleteRange({_0}, ({:?}, {:?}))", _1.0.as_ref().map(|a| EscapedBytes(&a)),  _1.1.as_ref().map(|a| EscapedBytes(&a)))]
     DeleteRange(TreeId, (Bound<Vec<u8>>, Bound<Vec<u8>>)),
+    #[debug("CreateTree({_0}, {}, {_2:?})", EscapedBytes(&_1))]
     CreateTree(TreeId, Vec<u8>, TreeOptions),
+    #[debug("DeleteTree({})", EscapedBytes(&_0))]
     DeleteTree(Vec<u8>),
+    #[debug("RenameTree({}, {})", EscapedBytes(&_0), EscapedBytes(&_1))]
     RenameTree(Vec<u8>, Vec<u8>),
 }
 

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -20,8 +20,11 @@ pub struct WriteBatch {
     inner: WriteBatchInner,
 }
 
+#[derive(Debug)]
 enum WriteBatchInner {
+    #[debug("InMemory({})", _0.len())]
     InMemory(Vec<u8>),
+    #[debug("DiskWriter(..)")]
     DiskWriter(BufWriter<File>),
 }
 
@@ -41,7 +44,7 @@ pub enum Operation {
     Insert(TreeId, Vec<u8>, Vec<u8>),
     Delete(TreeId, Vec<u8>),
     DeleteRange(TreeId, (Bound<Vec<u8>>, Bound<Vec<u8>>)),
-    CreateTree(Vec<u8>, TreeOptions),
+    CreateTree(TreeId, Vec<u8>, TreeOptions),
     DeleteTree(Vec<u8>),
     RenameTree(Vec<u8>, Vec<u8>),
 }
@@ -135,10 +138,12 @@ impl WriteBatch {
                         Operation::DeleteRange(tree_id, (start, end))
                     }
                     op_bytes::CREATE_TREE => {
+                        let mut tree_id = TreeId::default();
+                        bytes.read_exact(tree_id.as_bytes_mut())?;
                         let tree_name = read_u32_prefixed_bytes(bytes)?;
                         let options = read_u32_prefixed_bytes(bytes)?;
                         let options = TreeOptions::from_bytes(&options)?;
-                        Operation::CreateTree(tree_name, options)
+                        Operation::CreateTree(tree_id, tree_name, options)
                     }
                     op_bytes::DELETE_TREE => {
                         let tree_name = read_u32_prefixed_bytes(bytes)?;
@@ -192,7 +197,7 @@ impl WriteBatch {
         start: Bound<&[u8]>,
         end: Bound<&[u8]>,
     ) -> io::Result<()> {
-        let mut se = (([0u8], 0u32), ([0], 0));
+        let mut se = ((0u8, 0u32), (0u8, 0u32));
         let mut parts = SmallVec::<&[u8], 8>::new();
         parts.push(&[op_bytes::DELETE_RANGE]);
         parts.push(tree.as_bytes());
@@ -200,22 +205,29 @@ impl WriteBatch {
             match bound {
                 Bound::Unbounded => parts.push(&[0]),
                 Bound::Included(b) | Bound::Excluded(b) => {
-                    *u = [1 + matches!(bound, Bound::Excluded(_)) as u8];
+                    *u = 1 + matches!(bound, Bound::Excluded(_)) as u8;
                     *l = b.len() as u32;
-                    parts.extend_from_slice(&[u, l.as_bytes(), b]);
+                    parts.extend_from_slice(&[std::slice::from_ref(u), l.as_bytes(), b]);
                 }
             }
         }
         self.write_many(&parts)
     }
 
-    pub fn push_create_tree(&mut self, tree: &[u8], options: &[u8]) -> io::Result<()> {
+    pub fn push_create_tree(
+        &mut self,
+        tree_id: &TreeId,
+        tree: &[u8],
+        options: &TreeOptions,
+    ) -> io::Result<()> {
+        let options = options.to_bytes();
         self.write_many(&[
             &[op_bytes::CREATE_TREE],
+            tree_id.as_bytes(),
             (tree.len() as u32).as_bytes(),
             tree,
             (options.len() as u32).as_bytes(),
-            options,
+            &options,
         ])
     }
 
@@ -287,15 +299,6 @@ impl WriteBatch {
         match &mut self.inner {
             WriteBatchInner::InMemory(mem) => mem.clear(),
             WriteBatchInner::DiskWriter(_) => self.inner = WriteBatchInner::InMemory(Vec::new()),
-        }
-    }
-}
-
-impl std::fmt::Debug for WriteBatchInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InMemory(arg0) => f.debug_tuple("InMemory").field(&arg0.len()).finish(),
-            Self::DiskWriter(_) => f.debug_tuple("DiskWriter").finish(),
         }
     }
 }

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -42,17 +42,17 @@ mod op_bytes {
 #[derive(Debug)]
 pub enum Operation {
     Database(DbId),
-    #[debug("Insert({_0}, {}, {})", EscapedBytes(&_1), EscapedBytes(&_2))]
+    #[debug("Insert({_0}, {}, {})", EscapedBytes(_1), EscapedBytes(_2))]
     Insert(TreeId, Vec<u8>, Vec<u8>),
-    #[debug("Delete({_0}, {})", EscapedBytes(&_1))]
+    #[debug("Delete({_0}, {})", EscapedBytes(_1))]
     Delete(TreeId, Vec<u8>),
-    #[debug("DeleteRange({_0}, ({:?}, {:?}))", _1.0.as_ref().map(|a| EscapedBytes(&a)),  _1.1.as_ref().map(|a| EscapedBytes(&a)))]
+    #[debug("DeleteRange({_0}, ({:?}, {:?}))", _1.0.as_ref().map(|a| EscapedBytes(a)),  _1.1.as_ref().map(|a| EscapedBytes(a)))]
     DeleteRange(TreeId, (Bound<Vec<u8>>, Bound<Vec<u8>>)),
-    #[debug("CreateTree({_0}, {}, {_2:?})", EscapedBytes(&_1))]
+    #[debug("CreateTree({_0}, {}, {_2:?})", EscapedBytes(_1))]
     CreateTree(TreeId, Vec<u8>, TreeOptions),
-    #[debug("DeleteTree({})", EscapedBytes(&_0))]
+    #[debug("DeleteTree({})", EscapedBytes(_0))]
     DeleteTree(Vec<u8>),
-    #[debug("RenameTree({}, {})", EscapedBytes(&_0), EscapedBytes(&_1))]
+    #[debug("RenameTree({}, {})", EscapedBytes(_0), EscapedBytes(_1))]
     RenameTree(Vec<u8>, Vec<u8>),
 }
 


### PR DESCRIPTION
For Changelog
- [x] Multi-writer transactions
- [x] Fix deadlock between compaction and write transactions
- [x] `tx_id()` semantics changed. Write transactions do not return the previous tx_id + 1. `commit()` now returns the actual commit tx-id when successful.

Closes #5 